### PR TITLE
fix: 修复多轮对话后面板卡住的问题

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@
 格式基于 [Keep a Changelog](https://keepachangelog.com/zh-CN/1.0.0/)，
 版本号遵循 [语义化版本](https://semver.org/lang/zh-CN/)。
 
+## [1.6.3] - 2026-01-20
+
+### 修复
+- **[关键修复]** 修复多轮对话后面板卡住的问题：当新请求到来时，Webview 仍显示旧对话，提交/结束操作无响应。
+- **根本原因**：旧的 pending requests 没有被正确清理，导致新旧请求 ID 不匹配。
+- **解决方案**：
+  - `HttpService`: 新增 `clearAllPendingRequests()` 方法，当新请求到达时自动清理所有旧请求。
+  - `Webview`: 新增 `isActive` 状态标志，防止对过时请求进行操作。
+  - 增强日志记录，便于排查类似问题。
+
 ## [1.6.1] - 2026-01-15
 
 ### 修复

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "windsurf-chat-open",
   "displayName": "WindsurfChatOpen",
   "description": "开源版 WindsurfChat - 让 AI 停下来听你说话",
-  "version": "1.6.2",
+  "version": "1.6.3",
   "repository": {
     "type": "git",
     "url": "https://github.com/nicepkg/windsurf-chat-open"

--- a/src/panelTemplate.ts
+++ b/src/panelTemplate.ts
@@ -262,9 +262,15 @@ export function getPanelHtml(version: string = '0.0.0'): string {
     const waitingIndicator = document.getElementById('waitingIndicator');
     let images = [];
     let currentRequestId = '';
+    let isActive = false; // 新增: 追踪当前是否有活跃请求
 
     document.getElementById('btnSubmit').onclick = submit;
     document.getElementById('btnEnd').onclick = () => {
+      if (!isActive) {
+        console.log('[WindsurfChat WebView] No active request to end');
+        return;
+      }
+      isActive = false;
       waitingIndicator.classList.remove('show');
       vscode.postMessage({ type: 'end', requestId: currentRequestId });
     };
@@ -280,6 +286,11 @@ export function getPanelHtml(version: string = '0.0.0'): string {
     }
 
     function submit() {
+      if (!isActive) {
+        console.log('[WindsurfChat WebView] No active request to submit');
+        return;
+      }
+      isActive = false; // 提交后立即标记为非活跃，防止重复提交
       waitingIndicator.classList.remove('show');
       const text = inputText.value.trim();
       const validImages = images.filter(img => img !== null);
@@ -379,6 +390,7 @@ export function getPanelHtml(version: string = '0.0.0'): string {
       if (msg.type === 'showPrompt') {
         promptText.textContent = msg.prompt;
         currentRequestId = msg.requestId || '';
+        isActive = true; // 新增: 激活请求状态
         waitingIndicator.classList.add('show');
         inputText.focus();
         if (msg.startTimer) {


### PR DESCRIPTION
## 问题描述

在多轮对话后，面板会卡住——即使 AI 已经发起新请求，Webview 仍显示旧对话，提交/结束操作无响应。

## 根本原因

1. [HttpService](cci:2://file:///e:/GITHUB/windsurf-chat-open-master/src/httpService.ts:11:0-196:1) 中旧的 pending requests 没有被清理（只清理同 ID 的，但每次请求 ID 都不同）
2. Webview 中的 `currentRequestId` 与实际等待的请求不匹配
3. 用户操作发送的是旧请求 ID，无法匹配到新的 pending request

## 解决方案

### httpService.ts
- 新增 [clearAllPendingRequests()](cci:1://file:///e:/GITHUB/windsurf-chat-open-master/src/httpService.ts:92:4-110:5) 方法
- 当新请求到达时，先清理所有旧请求

### panelTemplate.ts
- Webview 添加 `isActive` 状态标志防止操作过时请求
- 操作后立即重置状态

## 测试

- [x] 编译通过
- [x] 多轮对话测试
- [x] 面板状态同步正常

- 新增 clearAllPendingRequests() 方法，当新请求到达时清理所有旧请求

- Webview 添加 isActive 状态标志防止操作过时请求

- 修复 requestId 不匹配导致的状态不同步问题